### PR TITLE
fix tree plot bug and speed up feature traj

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     limma,
     magrittr,
     metap,
-    MotrpacRatTraining6moData (>= 1.3.2),
+    MotrpacRatTraining6moData (>= 1.6.0),
     purrr,
     r2r,
     RColorBrewer,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: MotrpacRatTraining6mo
 Title: Analysis of the MoTrPAC endurance exercise training data in
     6-month-old rats
-Version: 1.1.0
+Version: 1.1.1
 Authors@R: c(
     person("Nicole", "Gay", , "nicole.r.gay@gmail.com", role = c("cre", "aut")),
     person("David", "Amar", , "ddam.am@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * Use `MotrpacRatTraining6moData::TRAINING_REGULATED_NORM_DATA` 
 and add a `training_regulated_only` argument to speed up `plot_feature_trajectories()` 
+* Fix bugs in `get_tree_plot_for_tissue()` and `get_trajectory_sizes_from_edge_sets()`
 
 # MotrpacRatTraining6mo 1.1.0 (2022-10-10)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * Use `MotrpacRatTraining6moData::TRAINING_REGULATED_NORM_DATA` 
 and add a `training_regulated_only` argument to speed up `plot_feature_trajectories()` 
 * Fix bugs in `get_tree_plot_for_tissue()` and `get_trajectory_sizes_from_edge_sets()`
+* Add `scale` argument to `call_pca_outliers()` (default `TRUE`)  
+* Set default values for arguments `plot` and `verbose` in `call_pca_outliers()` (default `TRUE`)  
 
 # MotrpacRatTraining6mo 1.1.0 (2022-10-10)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,8 @@
+# MotrpacRatTraining6mo 1.1.1 (2022-11-09)
+
+* Use `MotrpacRatTraining6moData::TRAINING_REGULATED_NORM_DATA` 
+and add a `training_regulated_only` argument to speed up `plot_feature_trajectories()` 
+
 # MotrpacRatTraining6mo 1.1.0 (2022-10-10)
 
 * Add `atac_call_outliers()` 

--- a/R/bayesian_graphical_clustering.R
+++ b/R/bayesian_graphical_clustering.R
@@ -466,21 +466,26 @@ limit_sets_by_regex <- function(sets, regs, append_semicol = TRUE){
 #' get_trajectory_sizes_from_edge_sets()
 get_trajectory_sizes_from_edge_sets <- function(edge_sets = MotrpacRatTraining6moData::GRAPH_COMPONENTS$edge_sets, 
                                                 min_size = 10){
-  node_names = unique(unlist(strsplit(names(edge_sets),split="---")))
+  sorted_names = sort(names(edge_sets))
+  arrs = strsplit(sorted_names, split="---")
+  # arrs = strsplit(names(edge_sets),split="---")
+  node_names = unique(unlist(arrs))
+  # node_names = unique(unlist(strsplit(names(edge_sets),split="---")))
   node_weeks = sapply(node_names,function(x)strsplit(x,split="_")[[1]][1])
   full_path_size = length(unique(node_weeks))
-  arrs = strsplit(names(edge_sets),split="---")
+
   prevs = sapply(arrs,function(x)x[1])
   nexts = sapply(arrs,function(x)x[2])
   l = list()
   l_sets = c()
-  for(j in 1:length(edge_sets)){
-    if(length(edge_sets[[j]])<min_size){next}
+  for(j in 1:length(sorted_names)){
+    edge_set = edge_sets[[sorted_names[[j]]]]
+    if(length(edge_set)<min_size){next}
     ind = length(l)+1
     curr_prev = prevs[j]
     curr_next = nexts[j]
     l[[ind]] = c(curr_prev,curr_next)
-    l_sets[[ind]] = edge_sets[[j]]
+    l_sets[[ind]] = edge_set
     for(j2 in 1:length(l)){
       j2_arr = l[[j2]]
       # here the path of j2 starts with the current edge next
@@ -489,7 +494,7 @@ get_trajectory_sizes_from_edge_sets <- function(edge_sets = MotrpacRatTraining6m
       if(j2_arr[1] == curr_next){
         new_ind = length(l)+1
         l[[new_ind]] = c(curr_prev,j2_arr)
-        l_sets[[new_ind]] = intersect(l_sets[[j2]],edge_sets[[j]])
+        l_sets[[new_ind]] = intersect(l_sets[[j2]],edge_set)
       }
       # here the path of j2 end with the current edge prev/start
       # so the edge represented by j can extend the path j2
@@ -497,7 +502,7 @@ get_trajectory_sizes_from_edge_sets <- function(edge_sets = MotrpacRatTraining6m
       if(j2_arr[length(j2_arr)]==curr_prev){
         new_ind = length(l)+1
         l[[new_ind]] = c(j2_arr,curr_next)
-        l_sets[[new_ind]] = intersect(l_sets[[j2]],edge_sets[[j]])
+        l_sets[[new_ind]] = intersect(l_sets[[j2]],edge_set)
       }
     }
     keep = sapply(l_sets,length) >= min_size
@@ -916,7 +921,7 @@ get_tree_plot_for_tissue <- function(
     d_g_our_layout[grepl(n,d_g_our_layout$name),"y"] = l_y_lim[1] + (j-1)*yjump
   }
   # make sure that the 0w node is in the same line as of the no response
-  d_g_our_layout[1,"y"] = d_g_our_layout[grepl("F0_M0",d_g_our_layout$name),"y"][1]
+  d_g_our_layout[d_g_our_layout$name == "0w","y"] = d_g_our_layout[grepl("F0_M0",d_g_our_layout$name),"y"][1]
   # set node sizes and other features
   igraph::V(d_g)$setsize = d_nodes[V(d_g)$name,"size"]
   igraph::V(d_g)$setsize[V(d_g)$name == "0w"] = stats::median(igraph::V(d_g)$setsize)

--- a/R/plot_sample_data.R
+++ b/R/plot_sample_data.R
@@ -13,6 +13,10 @@ plot_feature_logfc = function(){}
 #'   '[MotrpacRatTraining6moData::ASSAY_ABBREV];[MotrpacRatTraining6moData::TISSUE_ABBREV];feature_ID'
 #' @param exclude_outliers bool, whether to remove sample outliers specified by [MotrpacRatTraining6moData::OUTLIERS].
 #'   \code{TRUE} by default. 
+#' @param training_regulated_only bool, whether all input features are training-regulated at 5% FDR.
+#'   \code{FALSE} by default. If \code{TRUE}, data is loaded from 
+#'   [MotrpacRatTraining6moData::TRAINING_REGULATED_NORM_DATA] instead of with [load_sample_data()],
+#'   which dramatically improves performance. 
 #' @param center bool, whether to center the trajectories. \code{TRUE} by default.
 #' @param scale bool, whether to scale the trajectories. \code{TRUE} by default.
 #' @param title optional character, plot title
@@ -25,6 +29,13 @@ plot_feature_logfc = function(){}
 #' 
 #' @export 
 #' 
+#' @details Note that while features in the format 
+#'   '[MotrpacRatTraining6moData::ASSAY_ABBREV];[MotrpacRatTraining6moData::TISSUE_ABBREV];feature_ID'
+#'   are only given for training-regulated features in the data objects provided by 
+#'   \code{MotrpacRatTraining6moData}, one could specify non-training-regulated features by 
+#'   concatenating [MotrpacRatTraining6moData::ASSAY_ABBREV], [MotrpacRatTraining6moData::TISSUE_ABBREV],
+#'   and \code{feature_ID} for features of interest (semi-colon-separated). 
+#' 
 #' @examples 
 #' # Pick largest cluster in gastrocnemius 
 #' clust = extract_tissue_sets("SKM-GN", k=1, add_week8=FALSE)
@@ -32,7 +43,23 @@ plot_feature_logfc = function(){}
 #' names(clust)
 #' features = clust[["1w_F1_M1->2w_F1_M1->4w_F1_M1->8w_F1_M1"]]
 #' plot_feature_trajectories(features)
-plot_feature_trajectories = function(features, exclude_outliers=TRUE, center=TRUE, scale=TRUE, title=NULL, return_data=FALSE, scratchdir="."){
+#' 
+#' # Since we're only considering training-regulated features in this example,
+#' # set training_regulated_only to TRUE to make it slightly faster 
+#' plot_feature_trajectories(features, training_regulated_only=TRUE)
+#' 
+#' # Plot a mix of training-regulated and non-training-regulated features
+#' # Note this takes longer because the original datasets are downloaded 
+#' features = c(features, "TRNSCRPT;SKM-GN;ENSRNOG00000000008")
+#' plot_feature_trajectories(features)
+plot_feature_trajectories = function(features, 
+                                     training_regulated_only=FALSE, 
+                                     exclude_outliers=TRUE, 
+                                     center=TRUE, 
+                                     scale=TRUE, 
+                                     title=NULL, 
+                                     return_data=FALSE, 
+                                     scratchdir="."){
   
   if(!requireNamespace("viridis", quietly = TRUE) | !requireNamespace("viridisLite", quietly = TRUE)){
     stop(
@@ -41,79 +68,96 @@ plot_feature_trajectories = function(features, exclude_outliers=TRUE, center=TRU
     )
   }
   
-  message("Identifying data sets...")
   features = unique(features)
-  feature_dt = data.table::as.data.table(check_cluster_res_format(data.frame(feature=features, cluster="dummy")))
-  datasets = unique(feature_dt[,.(ome, tissue)])
-  omes = unique(datasets[,ome])
   
-  # choose which epigenetic dataset to use 
-  training_regulated_only = FALSE
-  if("ATAC" %in% omes | "METHYL" %in% omes){
-    epigen_input = feature_dt[ome %in% c("ATAC","METHYL"), feature]
-    epigen_training_reg = MotrpacRatTraining6moData::TRAINING_REGULATED_FEATURES$feature[MotrpacRatTraining6moData::TRAINING_REGULATED_FEATURES$assay %in% c("METHYL", "ATAC")]
-    if(all(epigen_input %in% epigen_training_reg)){
-      training_regulated_only = TRUE
+  # this is a default argument, but it's likely that all features are training-regulated 
+  # if this is the case, set training_regulated_only to TRUE to make things faster
+  if(!training_regulated_only){
+    training_reg = unique(MotrpacRatTraining6moData::TRAINING_REGULATED_FEATURES$feature)
+    if(length(features) <= length(training_reg)){
+      if(all(features %in% training_reg)){
+        training_regulated_only = TRUE
+      }
     }
   }
   
-  message("Compiling sample-level data...")
-  res = list()
-  for(i in 1:nrow(datasets)){
-    .ome = datasets[i, ome]
-    .tissue = datasets[i, tissue]
-    data = NULL
-    # get sample-level data 
-    if (.ome %in% c("ATAC","METHYL")){
-      data = load_sample_data(.tissue, 
-                              .ome, 
-                              normalized=TRUE, 
-                              training_regulated_only=training_regulated_only, 
-                              exclude_outliers=exclude_outliers, 
-                              scratchdir=scratchdir,
-                              warnings=TRUE)
+  if(training_regulated_only){
+    if(exclude_outliers){
+      data = data.table::as.data.table(fetch_object("TRAINING_REGULATED_NORM_DATA_NO_OUTLIERS"))
     }else{
-      data = load_sample_data(.tissue, 
-                              .ome, 
-                              normalized=TRUE, 
-                              training_regulated_only=FALSE, 
-                              exclude_outliers=exclude_outliers, 
-                              scratchdir=scratchdir,
-                              warnings=TRUE)
+      data = data.table::as.data.table(fetch_object("TRAINING_REGULATED_NORM_DATA"))
     }
-    if(is.null(data)) next
-    # convert colnames to PID
-    viallabel_cols = colnames(data)[grepl("^9", colnames(data))]
-    if(length(viallabel_cols)>0){
-      pids = viallabel_to_pid(viallabel_cols)
-      stopifnot(length(pids) == length(viallabel_cols))
-      stopifnot(length(pids) == length(unique(pids)))
-      # rename columns 
-      new_colnames = as.character(unname(pids[viallabel_cols]))
-      colnames(data)[grepl("^[0-9]", colnames(data))] = new_colnames
-    }
-    # add new feature column 
-    data = data.table::as.data.table(data)
-    data[,new_feature := sprintf("%s;%s;%s", assay, tissue, feature_ID)]
+    data = fix_cols(data)
     # select features 
-    curr_feat = feature_dt[ome==.ome & tissue==.tissue, feature]
-    data = data[feature %in% curr_feat | new_feature %in% curr_feat]
-    data[,feature := ifelse(feature %in% curr_feat, feature, new_feature)]
-    data[,new_feature := NULL]
-    if(nrow(data)>0){
-      # add to result
-      res[[sprintf("%s_%s",.ome,.tissue)]] = data
-    }else{
-      warning(sprintf("No unfiltered features for %s %s.", .ome, .tissue))
+    data = data[feature %in% features]
+    if(nrow(data)==0){
+      stop("No features in the input match training-regulated features in TRAINING_REGULATED_NORM_DATA.")
     }
+    sample_level_data = data
+  }else{
+    message("Identifying data sets...")
+    feature_dt = data.table::as.data.table(check_cluster_res_format(data.frame(feature=features, cluster="dummy")))
+    datasets = unique(feature_dt[,.(ome, tissue)])
+    omes = unique(datasets[,ome])
+    
+    # choose which epigenetic dataset to use 
+    epigen_training_regulated_only = FALSE
+    if("ATAC" %in% omes | "METHYL" %in% omes){
+      epigen_input = feature_dt[ome %in% c("ATAC","METHYL"), feature]
+      epigen_training_reg = MotrpacRatTraining6moData::TRAINING_REGULATED_FEATURES$feature[MotrpacRatTraining6moData::TRAINING_REGULATED_FEATURES$assay %in% c("METHYL", "ATAC")]
+      if(all(epigen_input %in% epigen_training_reg)){
+        epigen_training_regulated_only = TRUE
+      }
+    }
+    
+    message("Compiling sample-level data...")
+    res = list()
+    for(i in 1:nrow(datasets)){
+      .ome = datasets[i, ome]
+      .tissue = datasets[i, tissue]
+      data = NULL
+      # get sample-level data 
+      if (.ome %in% c("ATAC","METHYL")){
+        data = load_sample_data(.tissue, 
+                                .ome, 
+                                normalized=TRUE, 
+                                training_regulated_only=epigen_training_regulated_only, 
+                                exclude_outliers=exclude_outliers, 
+                                scratchdir=scratchdir,
+                                warnings=TRUE)
+      }else{
+        data = load_sample_data(.tissue, 
+                                .ome, 
+                                normalized=TRUE, 
+                                training_regulated_only=training_regulated_only, 
+                                exclude_outliers=exclude_outliers, 
+                                scratchdir=scratchdir,
+                                warnings=TRUE)
+      }
+      if(is.null(data)) next
+      curr_feat = feature_dt[ome==.ome & tissue==.tissue, feature]
+      data = fix_cols(data)
+      # add new feature column 
+      data[,new_feature := sprintf("%s;%s;%s", assay, tissue, feature_ID)]
+      # select features 
+      data = data[feature %in% curr_feat | new_feature %in% curr_feat]
+      data[,feature := ifelse(feature %in% curr_feat, feature, new_feature)]
+      data[,new_feature := NULL]
+      if(nrow(data)>0){
+        # add to result
+        res[[sprintf("%s_%s",.ome,.tissue)]] = data
+      }else{
+        warning(sprintf("No unfiltered features for %s %s.", .ome, .tissue))
+      }
+    }
+    if(length(res)==0){
+      warning(sprintf("No normalized data returned for datasets %s.",
+                      paste(paste(datasets[,ome], datasets[,tissue], sep=";"), collapse=", ")))
+      return()
+    }
+    
+    sample_level_data = data.table::rbindlist(res, fill=TRUE)
   }
-  if(length(res)==0){
-    warning(sprintf("No normalized data returned for datasets %s.",
-                    paste(paste(datasets[,ome], datasets[,tissue], sep=";"), collapse=", ")))
-    return()
-  }
-  
-  sample_level_data = data.table::rbindlist(res, fill=TRUE)
   
   # check if features are present 
   if(!all(features %in% sample_level_data[,feature])){
@@ -185,4 +229,20 @@ plot_feature_trajectories = function(features, exclude_outliers=TRUE, center=TRU
                    panel.grid.minor.y = ggplot2::element_blank())
   
   return(g)
+}
+
+fix_cols = function(data){
+  data = as.data.frame(data, check.names=FALSE)
+  # convert colnames to PID
+  viallabel_cols = colnames(data)[grepl("^9", colnames(data))]
+  if(length(viallabel_cols)>0){
+    pids = viallabel_to_pid(viallabel_cols)
+    stopifnot(length(pids) == length(viallabel_cols))
+    stopifnot(length(pids) == length(unique(pids)))
+    # rename columns 
+    new_colnames = as.character(unname(pids[viallabel_cols]))
+    colnames(data)[grepl("^[0-9]", colnames(data))] = new_colnames
+  }
+  data = data.table::as.data.table(data)
+  return(data)
 }

--- a/man/call_pca_outliers.Rd
+++ b/man/call_pca_outliers.Rd
@@ -7,8 +7,9 @@
 call_pca_outliers(
   norm,
   min_pc_ve,
-  plot,
-  verbose,
+  scale = TRUE,
+  plot = TRUE,
+  verbose = TRUE,
   iqr_coef = 3,
   M = Inf,
   title = NULL
@@ -19,9 +20,11 @@ call_pca_outliers(
 
 \item{min_pc_ve}{numeric, minimum percent variance explained by a PC to check it for outliers}
 
-\item{plot}{bool, whether to print PC plots before and after removing outliers}
+\item{scale}{bool, whether to scale input data before PCA. \code{TRUE} by default.}
 
-\item{verbose}{bool, whether to print descriptive strings}
+\item{plot}{bool, whether to print PC plots before and after removing outliers. \code{TRUE} by default.}
+
+\item{verbose}{bool, whether to print descriptive strings. \code{TRUE} by default.}
 
 \item{iqr_coef}{numeric, flag PC outliers if they are outside of IQR * \code{iqr_coef}}
 
@@ -46,8 +49,6 @@ components that explain some minimum variance.
 bat_rna_data = transcript_prep_data("BAT", covariates = NULL, outliers = NULL)
 bat_rna_outliers = call_pca_outliers(bat_rna_data$norm_data, 
                                      min_pc_ve=0.05, 
-                                     plot=TRUE, 
-                                     verbose=TRUE, 
                                      iqr_coef=5, 
                                      M=1000, 
                                      title="Brown Adipose")

--- a/man/plot_feature_trajectories.Rd
+++ b/man/plot_feature_trajectories.Rd
@@ -6,6 +6,7 @@
 \usage{
 plot_feature_trajectories(
   features,
+  training_regulated_only = FALSE,
   exclude_outliers = TRUE,
   center = TRUE,
   scale = TRUE,
@@ -17,6 +18,11 @@ plot_feature_trajectories(
 \arguments{
 \item{features}{character vector of features to plot in the format
 '\link[MotrpacRatTraining6moData:ASSAY_ABBREV]{MotrpacRatTraining6moData::ASSAY_ABBREV};\link[MotrpacRatTraining6moData:TISSUE_ABBREV]{MotrpacRatTraining6moData::TISSUE_ABBREV};feature_ID'}
+
+\item{training_regulated_only}{bool, whether all input features are training-regulated at 5\% FDR.
+\code{FALSE} by default. If \code{TRUE}, data is loaded from
+\link[MotrpacRatTraining6moData:TRAINING_REGULATED_NORM_DATA]{MotrpacRatTraining6moData::TRAINING_REGULATED_NORM_DATA} instead of with \code{\link[=load_sample_data]{load_sample_data()}},
+which dramatically improves performance.}
 
 \item{exclude_outliers}{bool, whether to remove sample outliers specified by \link[MotrpacRatTraining6moData:OUTLIERS]{MotrpacRatTraining6moData::OUTLIERS}.
 \code{TRUE} by default.}
@@ -39,11 +45,28 @@ a \code{\link[ggplot2:ggplot]{ggplot2::ggplot()}} object if \code{return_data=FA
 \description{
 Plot group means of a set of features from normalized sample-level data.
 }
+\details{
+Note that while features in the format
+'\link[MotrpacRatTraining6moData:ASSAY_ABBREV]{MotrpacRatTraining6moData::ASSAY_ABBREV};\link[MotrpacRatTraining6moData:TISSUE_ABBREV]{MotrpacRatTraining6moData::TISSUE_ABBREV};feature_ID'
+are only given for training-regulated features in the data objects provided by
+\code{MotrpacRatTraining6moData}, one could specify non-training-regulated features by
+concatenating \link[MotrpacRatTraining6moData:ASSAY_ABBREV]{MotrpacRatTraining6moData::ASSAY_ABBREV}, \link[MotrpacRatTraining6moData:TISSUE_ABBREV]{MotrpacRatTraining6moData::TISSUE_ABBREV},
+and \code{feature_ID} for features of interest (semi-colon-separated).
+}
 \examples{
 # Pick largest cluster in gastrocnemius 
 clust = extract_tissue_sets("SKM-GN", k=1, add_week8=FALSE)
 # Extract features 
 names(clust)
 features = clust[["1w_F1_M1->2w_F1_M1->4w_F1_M1->8w_F1_M1"]]
+plot_feature_trajectories(features)
+
+# Since we're only considering training-regulated features in this example,
+# set training_regulated_only to TRUE to make it slightly faster 
+plot_feature_trajectories(features, training_regulated_only=TRUE)
+
+# Plot a mix of training-regulated and non-training-regulated features
+# Note this takes longer because the original datasets are downloaded 
+features = c(features, "TRNSCRPT;SKM-GN;ENSRNOG00000000008")
 plot_feature_trajectories(features)
 }


### PR DESCRIPTION
* Use `MotrpacRatTraining6moData::TRAINING_REGULATED_NORM_DATA` 
and add a `training_regulated_only` argument to speed up `plot_feature_trajectories()` 
* Fix bugs in `get_tree_plot_for_tissue()` and `get_trajectory_sizes_from_edge_sets()`. Should not change existing results where the input edge list was not shuffled #32. Thanks for help from @jyu-sm 
* Require `MotrpacRatTraining6moData` v1.6.0 for `MotrpacRatTraining6moData::TRAINING_REGULATED_NORM_DATA` 
* Increment version