### PR TITLE
allow refmet IDs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,7 +2,7 @@ Type: Package
 Package: MotrpacRatTraining6mo
 Title: Analysis of the MoTrPAC endurance exercise training data in
     6-month-old rats
-Version: 1.6.0
+Version: 1.6.1
 Authors@R: c(
     person("Nicole", "Gay", , "nicole.r.gay@gmail.com", role = c("cre", "aut")),
     person("David", "Amar", , "ddam.am@gmail.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# MotrpacRatTraining6mo 1.6.1 (2023-02-05)  
+
+* Accommodate RefMet IDs as feature IDs in `plot_feature_normalized_data()` and `plot_feature_logfc()`.  
+
 # MotrpacRatTraining6mo 1.6.0 (2023-01-26)
 
 * Add functions for GSEA and PTM-SEA: `ssGSEA2_wrapper()`, `prepare_gsea_input()`, 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # MotrpacRatTraining6mo 1.6.1 (2023-02-05)  
 
 * Accommodate RefMet IDs as feature IDs in `plot_feature_normalized_data()` and `plot_feature_logfc()`.  
+* Pass the user-supplied version of the feature identifier when `plot_feature_logfc()` is called within `plot_feature_normalized_data()`.  
 
 # MotrpacRatTraining6mo 1.6.0 (2023-01-26)
 

--- a/R/plot_sample_data.R
+++ b/R/plot_sample_data.R
@@ -64,6 +64,13 @@
 #'                              add_adj_p = TRUE,
 #'                              facet_by_sex = TRUE)
 #'                              
+#' # Plot a metabolite using RefMet ID
+#' plot_feature_normalized_data(assay = "METAB",
+#'                              tissue = "LIVER",
+#'                              feature_ID = "Lactic acid",
+#'                              add_adj_p = TRUE,
+#'                              facet_by_sex = TRUE)
+#'                              
 plot_feature_normalized_data = function(assay = NULL,
                                         tissue = NULL, 
                                         feature_ID = NULL,
@@ -78,17 +85,34 @@ plot_feature_normalized_data = function(assay = NULL,
                                         ...){
   
   curr_feature = feature 
+  if(is.null(curr_feature) & any(is.null(c(assay, tissue, feature_ID)))){
+    stop("If 'feature' is not specified, 'assay', 'tissue', and 'feature_ID' must all be specified.")
+  }
+  # for metabolites, accommodate RefMet IDs
   if(is.null(curr_feature)){
-    if(any(is.null(c(assay, tissue, feature_ID)))){
-      stop("If 'feature' is not specified, 'assay', 'tissue', and 'feature_ID' must all be specified.")
+    original_feature_ID = feature_ID
+    if(assay == "METAB"){
+      # check if feature_ID is valid 
+      m = data.table(MotrpacRatTraining6moData::METAB_FEATURE_ID_MAP)
+      if(!feature_ID %in% m[,feature_ID_sample_data]){
+        # is it a RefMet ID?
+        if(feature_ID %in% m[,metabolite_refmet]){
+          # get feature_ID used in data
+          feature_ID = unique(m[metabolite_refmet == feature_ID, feature_ID_sample_data])[1]
+        }else{
+          stop(sprintf("Feature ID '%s' not found in METAB data. See METAB_FEATURE_ID_MAP for measured metabolites.", feature_ID))
+        }
+      }
     }
     curr_feature = sprintf("%s;%s;%s", assay, tissue, feature_ID)
   }
+
   if(is.null(tissue)){
     splits = unname(unlist(strsplit(curr_feature, ";")))
     assay = splits[1]
     tissue = splits[2]
     feature_ID = splits[3]
+    original_feature_ID = feature_ID
   }
   # rename to avoid conflict with data.table columns
   FEATURE_ID = feature_ID
@@ -390,6 +414,13 @@ plot_feature_normalized_data = function(assay = NULL,
 #'                    facet_by_sex = TRUE,
 #'                    add_adj_p = FALSE)
 #' 
+#' # Plot a metabolite using RefMet ID
+#' plot_feature_logfc(assay = "METAB",
+#'                    tissue = "LIVER",
+#'                    feature_ID = "Pyruvic acid",
+#'                    add_adj_p = TRUE,
+#'                    facet_by_sex = TRUE)
+#' 
 plot_feature_logfc = function(assay = NULL,
                               tissue = NULL, 
                               feature_ID = NULL,
@@ -404,17 +435,34 @@ plot_feature_logfc = function(assay = NULL,
                               ...){
   
   curr_feature = feature 
+  if(is.null(curr_feature) & any(is.null(c(assay, tissue, feature_ID)))){
+    stop("If 'feature' is not specified, 'assay', 'tissue', and 'feature_ID' must all be specified.")
+  }
+  # for metabolites, accommodate RefMet IDs
   if(is.null(curr_feature)){
-    if(any(is.null(c(assay, tissue, feature_ID)))){
-      stop("If 'feature' is not specified, 'assay', 'tissue', and 'feature_ID' must all be specified.")
+    original_feature_ID = feature_ID
+    if(assay == "METAB"){
+      # check if feature_ID is valid
+      m = data.table(MotrpacRatTraining6moData::METAB_FEATURE_ID_MAP)
+      if(!feature_ID %in% m[,feature_ID_sample_data]){
+        # is it a RefMet ID?
+        if(feature_ID %in% m[,metabolite_refmet]){
+          # get feature_ID used in data
+          feature_ID = unique(m[metabolite_refmet == feature_ID, feature_ID_sample_data])[1]
+        }else{
+          stop(sprintf("Feature ID '%s' not found in METAB data. See METAB_FEATURE_ID_MAP for measured metabolites.", feature_ID))
+        }
+      }
     }
     curr_feature = sprintf("%s;%s;%s", assay, tissue, feature_ID)
   }
+  
   if(is.null(tissue)){
     splits = unname(unlist(strsplit(curr_feature, ";")))
     assay = splits[1]
     tissue = splits[2]
     feature_ID = splits[3]
+    original_feature_ID = feature_ID
   }
   # rename to avoid conflict with data.table columns
   FEATURE_ID = feature_ID

--- a/R/plot_sample_data.R
+++ b/R/plot_sample_data.R
@@ -6,7 +6,7 @@
 #'
 #' @param assay NULL or `r assay()`
 #' @param tissue NULL or `r tissue()`
-#' @param feature_ID NULL or `r feature_ID()`
+#' @param feature_ID NULL or `r feature_ID()` or metabolite RefMet ID  
 #' @param feature NULL or `r feature()`. If NULL, \code{assay}, \code{tissue}, and 
 #'   \code{feature_ID} must all be specified. 
 #' @param title character, plot title. By default, the plot ID is \code{feature}. 
@@ -64,13 +64,6 @@
 #'                              add_adj_p = TRUE,
 #'                              facet_by_sex = TRUE)
 #'                              
-#' # Plot a metabolite using RefMet ID
-#' plot_feature_normalized_data(assay = "METAB",
-#'                              tissue = "LIVER",
-#'                              feature_ID = "Lactic acid",
-#'                              add_adj_p = TRUE,
-#'                              facet_by_sex = TRUE)
-#'                              
 plot_feature_normalized_data = function(assay = NULL,
                                         tissue = NULL, 
                                         feature_ID = NULL,
@@ -84,6 +77,7 @@ plot_feature_normalized_data = function(assay = NULL,
                                         add_adj_p = FALSE,
                                         ...){
   
+  use_feature = !is.null(feature)
   curr_feature = feature 
   if(is.null(curr_feature) & any(is.null(c(assay, tissue, feature_ID)))){
     stop("If 'feature' is not specified, 'assay', 'tissue', and 'feature_ID' must all be specified.")
@@ -179,7 +173,7 @@ plot_feature_normalized_data = function(assay = NULL,
   
   multiple_measurements = FALSE
   if(nrow(sample_level_data) > 1){
-    warning(sprintf("Multiple features correspond to '%s'. Plotting them together.", redundant_feature))
+    message(sprintf("Multiple features correspond to '%s'. Plotting them together.", redundant_feature))
     # make feature non-redundant
     sample_level_data[,feature := dataset]
     multiple_measurements = TRUE
@@ -332,11 +326,18 @@ plot_feature_normalized_data = function(assay = NULL,
   
   if(add_adj_p){
     message("Adding differential analysis p-value...")
-    da = plot_feature_logfc(assay = ASSAY,
-                            tissue = TISSUE,
-                            feature_ID = feature_ID,
-                            add_adj_p = TRUE, 
-                            return_data = TRUE)
+    if(use_feature){
+      da = plot_feature_logfc(feature = FEATURE,
+                              add_adj_p = TRUE, 
+                              return_data = TRUE)
+    }else{
+      da = plot_feature_logfc(assay = ASSAY,
+                              tissue = TISSUE,
+                              feature_ID = original_feature_ID,
+                              add_adj_p = TRUE, 
+                              return_data = TRUE)
+    }
+
     if(!is.null(da)){
       adj_p_value = min(unique(da$selection_fdr), na.rm=TRUE)
       subtitle = sprintf("adj. p-value: %s", signif(adj_p_value, digits=2))
@@ -354,7 +355,7 @@ plot_feature_normalized_data = function(assay = NULL,
 #'
 #' @param assay NULL or `r assay()`
 #' @param tissue NULL or `r tissue()`
-#' @param feature_ID NULL or `r feature_ID()`
+#' @param feature_ID NULL or `r feature_ID()` or metabolite RefMet ID 
 #' @param feature NULL or `r feature()`. If NULL, \code{assay}, \code{tissue}, and 
 #'   \code{feature_ID} must all be specified. 
 #' @param title character, plot title. By default, the plot ID is \code{feature}. 
@@ -413,13 +414,6 @@ plot_feature_normalized_data = function(assay = NULL,
 #'                    scale_x_by_time = FALSE,
 #'                    facet_by_sex = TRUE,
 #'                    add_adj_p = FALSE)
-#' 
-#' # Plot a metabolite using RefMet ID
-#' plot_feature_logfc(assay = "METAB",
-#'                    tissue = "LIVER",
-#'                    feature_ID = "Pyruvic acid",
-#'                    add_adj_p = TRUE,
-#'                    facet_by_sex = TRUE)
 #' 
 plot_feature_logfc = function(assay = NULL,
                               tissue = NULL, 
@@ -568,7 +562,7 @@ plot_feature_logfc = function(assay = NULL,
   multiple_measurements = FALSE
   ADJ_P = unique(curr_timewise_dea[,selection_fdr])
   if(length(ADJ_P)>1){
-    warning(sprintf("Multiple measurements for feature '%s'. Taking the smallest training-dea FDR for the plot label.",curr_feature))
+    message(sprintf("Multiple measurements for feature '%s'. Taking the smallest training-dea FDR for the plot label.",curr_feature))
     ADJ_P = min(ADJ_P, na.rm=TRUE)
     curr_timewise_dea[,feature := dataset]
     multiple_measurements = TRUE

--- a/man/plot_feature_logfc.Rd
+++ b/man/plot_feature_logfc.Rd
@@ -96,4 +96,11 @@ plot_feature_logfc(assay = "METAB",
                    facet_by_sex = TRUE,
                    add_adj_p = FALSE)
 
+# Plot a metabolite using RefMet ID
+plot_feature_logfc(assay = "METAB",
+                   tissue = "LIVER",
+                   feature_ID = "Pyruvic acid",
+                   add_adj_p = TRUE,
+                   facet_by_sex = TRUE)
+
 }

--- a/man/plot_feature_logfc.Rd
+++ b/man/plot_feature_logfc.Rd
@@ -24,7 +24,7 @@ plot_feature_logfc(
 
 \item{tissue}{NULL or character, tissue abbreviation, one of \link[MotrpacRatTraining6moData:TISSUE_ABBREV]{MotrpacRatTraining6moData::TISSUE_ABBREV}}
 
-\item{feature_ID}{NULL or character, MoTrPAC feature identifier}
+\item{feature_ID}{NULL or character, MoTrPAC feature identifier or metabolite RefMet ID}
 
 \item{feature}{NULL or character, unique feature identifier in the format '\link[MotrpacRatTraining6moData:ASSAY_ABBREV]{MotrpacRatTraining6moData::ASSAY_ABBREV};\link[MotrpacRatTraining6moData:TISSUE_ABBREV]{MotrpacRatTraining6moData::TISSUE_ABBREV};feature_ID' only for training-regulated features at 5\% IHW FDR. For redundant differential features, 'feature_ID' is prepended with the specific platform to make unique identifiers. See \link[MotrpacRatTraining6moData:REPEATED_FEATURES]{MotrpacRatTraining6moData::REPEATED_FEATURES} for details.. If NULL, \code{assay}, \code{tissue}, and
 \code{feature_ID} must all be specified.}
@@ -95,12 +95,5 @@ plot_feature_logfc(assay = "METAB",
                    scale_x_by_time = FALSE,
                    facet_by_sex = TRUE,
                    add_adj_p = FALSE)
-
-# Plot a metabolite using RefMet ID
-plot_feature_logfc(assay = "METAB",
-                   tissue = "LIVER",
-                   feature_ID = "Pyruvic acid",
-                   add_adj_p = TRUE,
-                   facet_by_sex = TRUE)
 
 }

--- a/man/plot_feature_normalized_data.Rd
+++ b/man/plot_feature_normalized_data.Rd
@@ -96,4 +96,11 @@ plot_feature_normalized_data(assay = "METAB",
                              add_adj_p = TRUE,
                              facet_by_sex = TRUE)
                              
+# Plot a metabolite using RefMet ID
+plot_feature_normalized_data(assay = "METAB",
+                             tissue = "LIVER",
+                             feature_ID = "Lactic acid",
+                             add_adj_p = TRUE,
+                             facet_by_sex = TRUE)
+                             
 }

--- a/man/plot_feature_normalized_data.Rd
+++ b/man/plot_feature_normalized_data.Rd
@@ -24,7 +24,7 @@ plot_feature_normalized_data(
 
 \item{tissue}{NULL or character, tissue abbreviation, one of \link[MotrpacRatTraining6moData:TISSUE_ABBREV]{MotrpacRatTraining6moData::TISSUE_ABBREV}}
 
-\item{feature_ID}{NULL or character, MoTrPAC feature identifier}
+\item{feature_ID}{NULL or character, MoTrPAC feature identifier or metabolite RefMet ID}
 
 \item{feature}{NULL or character, unique feature identifier in the format '\link[MotrpacRatTraining6moData:ASSAY_ABBREV]{MotrpacRatTraining6moData::ASSAY_ABBREV};\link[MotrpacRatTraining6moData:TISSUE_ABBREV]{MotrpacRatTraining6moData::TISSUE_ABBREV};feature_ID' only for training-regulated features at 5\% IHW FDR. For redundant differential features, 'feature_ID' is prepended with the specific platform to make unique identifiers. See \link[MotrpacRatTraining6moData:REPEATED_FEATURES]{MotrpacRatTraining6moData::REPEATED_FEATURES} for details.. If NULL, \code{assay}, \code{tissue}, and
 \code{feature_ID} must all be specified.}
@@ -93,13 +93,6 @@ plot_feature_normalized_data(assay = "METAB",
                              tissue = "PLASMA",
                              feature_ID = "glucose",
                              scale_x_by_time = FALSE,
-                             add_adj_p = TRUE,
-                             facet_by_sex = TRUE)
-                             
-# Plot a metabolite using RefMet ID
-plot_feature_normalized_data(assay = "METAB",
-                             tissue = "LIVER",
-                             feature_ID = "Lactic acid",
                              add_adj_p = TRUE,
                              facet_by_sex = TRUE)
                              

--- a/tests/testthat/test-plot_sample_data.R
+++ b/tests/testthat/test-plot_sample_data.R
@@ -6,3 +6,19 @@ test_that("warn if feature does not exist", {
                                     tissue = "ADRNL",
                                     feature_ID = "glucose"))
 })
+
+test_that("feature is correctly passed for logfc", {
+  expect_message(plot_feature_normalized_data(feature = "METAB;SKM-GN;meta-reg:GMP",
+                                              add_adj_p = TRUE))
+})
+
+test_that("RefMet IDs are handled", {
+  expect_message(plot_feature_normalized_data(assay = "METAB",
+                                              tissue = "LIVER",
+                                              feature_ID = "Lactic acid",
+                                              add_adj_p = TRUE))
+  expect_message(plot_feature_logfc(assay = "METAB",
+                                    tissue = "LIVER",
+                                    feature_ID = "Lactic acid",
+                                    add_adj_p = TRUE))
+})


### PR DESCRIPTION
* Accommodate RefMet IDs as feature IDs in `plot_feature_normalized_data()` and `plot_feature_logfc()`.  
* Pass the user-supplied version of the feature identifier when `plot_feature_logfc()` is called within `plot_feature_normalized_data()`.