### PR TITLE
#52 vena cava bug fix

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# MotrpacRatTraining6mo 1.6.3 (2023-06-02)
+
+* Bug fix in `transcript_timewise_da()` to run with limited contrasts when `tissue="VENACV"`.
+
 # MotrpacRatTraining6mo 1.6.2 (2023-03-09)
 
 * Bug fix in `atac_timewise_da()` and `atac_training_da()` when `n_features = Inf`. 

--- a/R/transcript_differential_analysis.R
+++ b/R/transcript_differential_analysis.R
@@ -175,6 +175,7 @@ run_deseq = function(counts, meta, covar, outcome_of_interest, contrasts, dds=NU
 #' # Same as the first example but save the [DESeq2::DESeq2()] DESeqResults objects in an RData file 
 #' da = transcript_timewise_da("BAT", rdata_outfile = "~/test/BAT_RNA_DA.RData", overwrite = TRUE)
 #' }
+#' 
 transcript_timewise_da = function(tissue, 
                                   covariates = c('pct_globin', 'RIN', 'pct_umi_dup', 'median_5_3_bias'), 
                                   outliers = na.omit(MotrpacRatTraining6moData::OUTLIERS$viallabel),
@@ -217,7 +218,8 @@ transcript_timewise_da = function(tissue,
     
     contrasts = list()
     i = 1
-    for (tp in c('1w','2w','4w','8w')){
+    groups = na.omit(unique(curr_meta[,group]))
+    for (tp in groups[groups != "control"]){
       contrasts[[i]] = c('group', tp, 'control')
       i = i+1
     }

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -130,11 +130,24 @@ utils::globalVariables(
     ########################################### metabolomics meta
     "metabolite_refmet",
     "site",
-    ########################################### plot_sample_data
+    ########################################### plot_sample_data()
     "expr",
     "plot_group",
-    ########################################### gene_pathway_enrichment
+    ########################################### gene_pathway_enrichment()
     "BH_adj_p_value",
     "Phenotype",
-    "parents"
+    "parents",
+    ########################################### plot_feature_logfc()
+    "feature_ID_sample_data",
+    "plot_feature_normalized_data",
+    ########################################### gsea
+    "ensembl",
+    "entrez",
+    "entrez_gene",
+    "flanking_sequence",
+    "gene",
+    "ptm_id_human_uniprot",
+    "ptm_id_rat_refseq",
+    "refseq",
+    "signed_logpval"
   ))

--- a/man/transcript_timewise_da.Rd
+++ b/man/transcript_timewise_da.Rd
@@ -74,4 +74,5 @@ da = transcript_timewise_da("BAT", add_shrunk_logfc = FALSE)
 # Same as the first example but save the [DESeq2::DESeq2()] DESeqResults objects in an RData file 
 da = transcript_timewise_da("BAT", rdata_outfile = "~/test/BAT_RNA_DA.RData", overwrite = TRUE)
 }
+
 }


### PR DESCRIPTION
Fix a bug in `transcript_timewise_da()` to avoid an error due to missing 1-week and 2-week female samples in vena cava. Reported in #52 